### PR TITLE
Remove URLSanitizer from app chooser dialogue

### DIFF
--- a/app/src/main/java/moe/dic1911/urlsanitizer/MainActivity.java
+++ b/app/src/main/java/moe/dic1911/urlsanitizer/MainActivity.java
@@ -112,12 +112,12 @@ public class MainActivity extends AppCompatActivity {
         ArrayList <Intent> targetedShareIntents = new ArrayList<>();
         Intent rawIntent = createShareIntent(action, result);
 
-        if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             targetedShareIntents.add(rawIntent);
             return targetedShareIntents;
         }
 
-        List <ResolveInfo> resolvedActivities = getPackageManager().queryIntentActivities(rawIntent,0);//PackageManager.MATCH_ALL);
+        List <ResolveInfo> resolvedActivities = getPackageManager().queryIntentActivities(rawIntent,0);
 
         for (ResolveInfo info : resolvedActivities) {
             if (info.activityInfo.packageName.toLowerCase(Locale.ROOT).equals(getPackageName().toLowerCase(Locale.ROOT)))
@@ -155,11 +155,6 @@ public class MainActivity extends AppCompatActivity {
         }
 
         return finalIntent;
-    }
-
-    protected boolean isDefaultBrowser () {
-        List <ResolveInfo> v = getPackageManager().queryIntentActivities(new Intent(Intent.ACTION_VIEW,Uri.parse("https://searx.info")),PackageManager.MATCH_DEFAULT_ONLY);
-        return v.size()==1 && v.get(0).activityInfo.packageName.toLowerCase(Locale.ROOT).equals(getPackageName().toLowerCase(Locale.ROOT));
     }
 
 }

--- a/app/src/main/java/moe/dic1911/urlsanitizer/MainActivity.java
+++ b/app/src/main/java/moe/dic1911/urlsanitizer/MainActivity.java
@@ -1,8 +1,14 @@
 package moe.dic1911.urlsanitizer;
 
+import android.content.ComponentName;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -10,6 +16,12 @@ import android.view.View;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -23,16 +35,14 @@ public class MainActivity extends AppCompatActivity {
         String appLinkAction = appLinkIntent.getAction();
         Uri appLinkData = appLinkIntent.getData();
         Uri result;
+
         if (appLinkAction.equals(Intent.ACTION_VIEW) && appLinkData != null) {
             // handle query and stuff then rebuild the uri
             result = new UrlHandler(this, blh, appLinkData).sanitize();
             if (result == null) quit();
 
             // open link
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            Uri target = result;
-            intent.setData(target);
-            startActivity(Intent.createChooser(intent, target.toString()));
+            startChooserActivity(Intent.ACTION_VIEW, result, result.toString());
             quit();
         } else if (appLinkAction.equals(Intent.ACTION_SEND)) {
             String txt = appLinkIntent.getStringExtra(Intent.EXTRA_TEXT);
@@ -41,10 +51,7 @@ public class MainActivity extends AppCompatActivity {
                 if (result == null) quit();
 
                 // share again
-                Intent intent = new Intent(Intent.ACTION_SEND);
-                intent.setType("text/plain");
-                intent.putExtra(Intent.EXTRA_TEXT, result.toString());
-                startActivity(Intent.createChooser(intent, "Share link via..."));
+                startChooserActivity(Intent.ACTION_SEND, result, "Share link via...");
             }
             quit();
         }
@@ -83,4 +90,76 @@ public class MainActivity extends AppCompatActivity {
         finishAffinity();
         System.exit(0);
     }
+
+    protected void startChooserActivity (String action, Uri result, String chooserTitle) {
+        ArrayList <Intent> targetedShareIntents = buildTargetedShareIntents(action, result);
+
+        Intent targetIntent = targetedShareIntents.remove(0);
+        Intent chooserIntent = Intent.createChooser(targetIntent, chooserTitle);
+
+        Parcelable[] targetedShareParceledIntents = new Parcelable[targetedShareIntents.size()];
+        for (int i=0; i<targetedShareIntents.size(); ++i)
+            targetedShareParceledIntents[i] = targetedShareIntents.get(i);
+
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetedShareParceledIntents);
+        chooserIntent.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, new ComponentName[] {new ComponentName(this, MainActivity.class)} );
+
+        startActivity(chooserIntent);
+
+    }
+
+    protected ArrayList <Intent> buildTargetedShareIntents (String action, Uri result) {
+        ArrayList <Intent> targetedShareIntents = new ArrayList<>();
+        Intent rawIntent = createShareIntent(action, result);
+
+        if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            targetedShareIntents.add(rawIntent);
+            return targetedShareIntents;
+        }
+
+        List <ResolveInfo> resolvedActivities = getPackageManager().queryIntentActivities(rawIntent,0);//PackageManager.MATCH_ALL);
+
+        for (ResolveInfo info : resolvedActivities) {
+            if (info.activityInfo.packageName.toLowerCase(Locale.ROOT).equals(getPackageName().toLowerCase(Locale.ROOT)))
+                continue;
+
+            Intent targetedShareIntent = createShareIntent(action, result);
+            targetedShareIntent.setPackage(info.activityInfo.packageName);
+            targetedShareIntents.add(targetedShareIntent);
+        }
+
+        if (targetedShareIntents.isEmpty()) {
+            targetedShareIntents = new ArrayList<>();
+            targetedShareIntents.add(rawIntent);
+        }
+
+        return targetedShareIntents;
+    }
+
+    protected Intent createShareIntent (String action, Uri result) {
+        Intent finalIntent = new Intent();
+        finalIntent.setAction(action);
+
+        switch (action) {
+            case Intent.ACTION_VIEW:
+                finalIntent.setData(result);
+                break;
+
+            case Intent.ACTION_SEND:
+                finalIntent.setType("text/plain");
+                finalIntent.putExtra(Intent.EXTRA_TEXT, result.toString());
+                break;
+
+            default:
+                break;
+        }
+
+        return finalIntent;
+    }
+
+    protected boolean isDefaultBrowser () {
+        List <ResolveInfo> v = getPackageManager().queryIntentActivities(new Intent(Intent.ACTION_VIEW,Uri.parse("https://searx.info")),PackageManager.MATCH_DEFAULT_ONLY);
+        return v.size()==1 && v.get(0).activityInfo.packageName.toLowerCase(Locale.ROOT).equals(getPackageName().toLowerCase(Locale.ROOT));
+    }
+
 }


### PR DESCRIPTION
Currently, clicking URLSanitizer on the app chooser dialogue sends another intent with the sanitized URL. With this change, URLSanitizer will not appear among the list of apps for the sanitized URL.

Works by customizing intents passed to Intent.createChooser() and removing our app among the list.

Tested working for Android 10 and will work for on API levels 21 and above.