### PR TITLE
Added additional Twitter-related domains

### DIFF
--- a/app/src/main/java/moe/dic1911/urlsanitizer/Constants.java
+++ b/app/src/main/java/moe/dic1911/urlsanitizer/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
     public static final String DEFAULT_INSTAGRAM_TARGET = "bibliogram.art";
 
     public static final List<String> YOUTUBE_DOMAINS = Arrays.asList("youtu.be", "youtube.com", "www.youtube.com");
-    public static final List<String> TWITTER_DOMAINS = Arrays.asList("twitter.com", "mobile.twitter.com", "x.com", "mobile.x.com");
+    public static final List<String> TWITTER_DOMAINS = Arrays.asList("twitter.com", "mobile.twitter.com", "x.com", "mobile.x.com", "fxtwitter.com", "vxtwitter.com", "fixupx.com");
     public static final List<String> REDDIT_DOMAINS = Arrays.asList("reddit.com", "www.reddit.com", "old.reddit.com");
     public static final List<String> INSTAGRAM_DOMAINS = Arrays.asList("instagram.com", "www.instagram.com", "instagr.am", "instagr.com");
 


### PR DESCRIPTION
Added some domains that relate to twitter.    
#21 :
fxtwitter.com

https://github.com/dic1911/android_URLSanitizer/issues/21#issuecomment-2577238023 :
vxtwitter.com
fixupx.com