### PR TITLE
add de locale to fastlane and improve formatting for other fulldescs

### DIFF
--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+entferne die nervenden Tracking-Parameter aus URLs

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,15 +1,18 @@
 Don't like those tracking GET queries from the big brothers? Here, this app got your back.
-Features:
 
-Cleanup URLs when opening link
-Sharing URLs to this app also cleans the URL
+<b>Features:</b>
 
-How to use:
-Opening a link: Simply open the link with this app first, and choose the app you want to use to open the link afterwards.
-Sharing a link: Share to this app first, and choose the app you want the link to share to afterwards.
-Adding missing GET query(ies): Open the app, fill the query in, then tap on "Add Entry" button.
+* Cleanup URLs when opening link
+* Sharing URLs to this app also cleans the URL
+
+<b>How to use:</b>
+
+* <b>Opening a link:</b> Simply open the link with this app first, and choose the app you want to use to open the link afterwards.
+* <b>Sharing a link:</b> Share to this app first, and choose the app you want the link to share to afterwards.
+* <b>Adding missing GET query(ies):</b> Open the app, fill the query in, then tap on "Add Entry" button.
+
 (Note. Wildcard is supported since 1.3.0, check default entries for usage)
 
-How it works:
+<b>How it works:</b>
 
 This app handles Android intent to open/share link, so the app can get the URL and modify it, get rid of those dirty query and create another intent for your original action.

--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,14 +1,18 @@
 ¿No te gustan esas molestas consultas GET de rastreo de los grandes hermanos? Esta app te cubre las espaldas.
 
 Funciones:
+
 - Limpiar URLs al abrir enlaces
 - Compartir URLs a esta app también limpia el enlace
 
 Cómo usarlo:
-Abrir un enlace: Simplemente ábrelo primero con esta app, luego elige la app donde quieres abrirlo.
-Compartir un enlace: Compártelo primero a esta app, luego selecciona dónde quieres enviarlo.
-Añadir consultas GET faltantes: Abre la app, ingresa la consulta y toca "Añadir Entrada".
+
+* Abrir un enlace: Simplemente ábrelo primero con esta app, luego elige la app donde quieres abrirlo.
+* Compartir un enlace: Compártelo primero a esta app, luego selecciona dónde quieres enviarlo.
+* Añadir consultas GET faltantes: Abre la app, ingresa la consulta y toca "Añadir Entrada".
+
 (Nota: Desde la versión 1.3.0 soporta wildcards, revisa las entradas predeterminadas para ver ejemplos)
 
 Cómo funciona:
+
 Esta app maneja intents de Android para abrir/compartir enlaces, modificando la URL para eliminar esas consultas de rastreo y crear un nuevo intent para tu acción original.


### PR DESCRIPTION
This PR slightly adjusts formatting of the full descriptions, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with short and full description.